### PR TITLE
Reset cookie on logout

### DIFF
--- a/js/user.js
+++ b/js/user.js
@@ -73,6 +73,7 @@ function logout()
     firstName = "";
     lastName = "";
     window.location.href = "index.html";
+    document.cookie = "";
 }
 
 function register()


### PR DESCRIPTION
When the user logs out, reset the browser's cookie to forget the user. Previously, this would simply take them to the homepage and reset the browser's memory, but the cookie would still exist so it would not actually log the user out. 